### PR TITLE
Add futures demo page with trading view charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+    <meta charset="UTF-8">
+    <title>国内期货展示</title>
+    <style>
+        body {font-family: Arial, sans-serif; margin: 0; padding: 0;}
+        #chart {width: 100%; height: 500px;}
+    </style>
+</head>
+<body>
+    <h1>国内期货示例图表</h1>
+    <div id="chart"></div>
+
+    <script src="https://unpkg.com/lightweight-charts@3.8.0/dist/lightweight-charts.standalone.production.js"></script>
+    <script>
+        // 示例数据（假设是某国内期货合约的日线数据）
+        const candleData = [
+            { time: '2023-06-01', open: 3430, high: 3480, low: 3410, close: 3460 },
+            { time: '2023-06-02', open: 3460, high: 3490, low: 3440, close: 3450 },
+            { time: '2023-06-05', open: 3450, high: 3500, low: 3420, close: 3490 },
+            { time: '2023-06-06', open: 3490, high: 3510, low: 3470, close: 3505 },
+            { time: '2023-06-07', open: 3505, high: 3530, low: 3490, close: 3515 },
+            { time: '2023-06-08', open: 3515, high: 3540, low: 3500, close: 3520 },
+            { time: '2023-06-09', open: 3520, high: 3550, low: 3510, close: 3535 },
+            { time: '2023-06-12', open: 3535, high: 3560, low: 3520, close: 3550 },
+            { time: '2023-06-13', open: 3550, high: 3570, low: 3530, close: 3565 },
+            { time: '2023-06-14', open: 3565, high: 3580, low: 3550, close: 3540 },
+            { time: '2023-06-15', open: 3540, high: 3560, low: 3520, close: 3530 },
+            { time: '2023-06-16', open: 3530, high: 3550, low: 3510, close: 3525 }
+        ];
+
+        // 计算简单移动平均线
+        function calculateSMA(data, period) {
+            return data.map((d, index) => {
+                if (index < period - 1) return { time: d.time, value: null };
+                let sum = 0;
+                for (let i = index - period + 1; i <= index; i++) {
+                    sum += data[i].close;
+                }
+                return { time: d.time, value: sum / period };
+            });
+        }
+
+        const smaData = calculateSMA(candleData, 3); // 简单使用3日均线作为示例
+
+        // 寻找买卖点：收盘价上穿/下穿均线
+        const buySellMarkers = [];
+        for (let i = 1; i < candleData.length; i++) {
+            const prevClose = candleData[i - 1].close;
+            const close = candleData[i].close;
+            const prevSma = smaData[i - 1].value;
+            const sma = smaData[i].value;
+            if (prevClose < prevSma && close > sma) {
+                buySellMarkers.push({ time: candleData[i].time, position: 'belowBar', color: 'green', shape: 'arrowUp', text: '买入' });
+            }
+            if (prevClose > prevSma && close < sma) {
+                buySellMarkers.push({ time: candleData[i].time, position: 'aboveBar', color: 'red', shape: 'arrowDown', text: '卖出' });
+            }
+        }
+
+        const chart = LightweightCharts.createChart(document.getElementById('chart'), {
+            width: document.body.clientWidth,
+            height: 500,
+        });
+        const candleSeries = chart.addCandlestickSeries();
+        candleSeries.setData(candleData);
+
+        const smaSeries = chart.addLineSeries({ color: 'blue' });
+        smaSeries.setData(smaData.filter(d => d.value !== null));
+
+        candleSeries.setMarkers(buySellMarkers);
+
+        window.addEventListener('resize', () => {
+            chart.applyOptions({ width: document.body.clientWidth });
+        });
+    </script>
+</body>
+</html>

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,5 @@
-heelo
+# 国内期货展示示例
+
+此仓库包含一个简单的静态页面 `index.html`，使用 TradingView 开源的 [Lightweight Charts](https://github.com/tradingview/lightweight-charts) 库展示国内期货数据，并给出基于简单移动平均线的买卖提示。
+
+打开 `index.html` 即可查看示例图表。


### PR DESCRIPTION
## Summary
- add an example `index.html` page using TradingView Lightweight Charts
- compute a simple moving average and highlight buy/sell markers
- update README with instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cb6082c0c832abd8b230a8ebc95b6